### PR TITLE
Add ERPNext 15 Docker image build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,63 @@
+name: Docker image
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 10 * * 1"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/docker-image.yml"
+      - "docker/**"
+      - "optics_erp/**"
+      - "pyproject.toml"
+
+permissions:
+  contents: read
+
+env:
+  IMAGE_NAME: bgd4000/optics_erp
+  FRAPPE_BRANCH: version-15
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout app
+        uses: actions/checkout@v4
+
+      - name: Checkout frappe_docker
+        uses: actions/checkout@v4
+        with:
+          repository: frappe/frappe_docker
+          path: frappe_docker
+
+      - name: Prepare apps.json
+        id: apps
+        run: echo "apps_json_base64=$(base64 -w 0 docker/apps.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: frappe_docker
+          file: frappe_docker/images/custom/Containerfile
+          push: true
+          build-args: |
+            FRAPPE_PATH=https://github.com/frappe/frappe
+            FRAPPE_BRANCH=${{ env.FRAPPE_BRANCH }}
+            APPS_JSON_BASE64=${{ steps.apps.outputs.apps_json_base64 }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:erpnext-v15
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -8,9 +8,23 @@ You can install this app using the [bench](https://github.com/frappe/bench) CLI:
 
 ```bash
 cd $PATH_TO_YOUR_BENCH
-bench get-app $URL_OF_THIS_REPO --branch develop
+bench get-app https://github.com/BaraaJayousi/optics_erp_15 --branch main
 bench install-app optics_erp
 ```
+
+### Docker image
+
+This repository includes a Docker build manifest for ERPNext 15 in `docker/apps.json`.
+The image is intended to be built with the official `frappe_docker` custom image flow:
+
+```powershell
+.\docker\build.ps1 -Image bgd4000/optics_erp -Tag erpnext-v15
+docker push bgd4000/optics_erp:erpnext-v15
+docker push bgd4000/optics_erp:latest
+```
+
+The build tracks the latest ERPNext 15 line by using the upstream `version-15` branches
+for Frappe and ERPNext, and includes this app from the `main` branch.
 
 ### Contributing
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,46 @@
+# Docker Build
+
+This folder defines the custom ERPNext 15 image for `bgd4000/optics_erp`.
+
+The image is built with Frappe Docker's custom image flow and installs:
+
+- Frappe from `version-15`
+- ERPNext from `version-15`
+- Optics ERP from `BaraaJayousi/optics_erp_15`, branch `main`
+
+## Build on Windows PowerShell
+
+From the repository root:
+
+```powershell
+.\docker\build.ps1 -Image bgd4000/optics_erp -Tag erpnext-v15
+```
+
+Push after logging in to Docker Hub:
+
+```powershell
+docker login
+docker push bgd4000/optics_erp:erpnext-v15
+docker push bgd4000/optics_erp:latest
+```
+
+## Use in Frappe Docker
+
+In your `.env` file for the running Docker setup:
+
+```env
+CUSTOM_IMAGE=bgd4000/optics_erp
+CUSTOM_TAG=erpnext-v15
+PULL_POLICY=always
+```
+
+Then recreate the containers using your existing compose command.
+
+After the containers start, run migration and rebuild assets for your site:
+
+```powershell
+docker compose exec backend bench --site your-site-name migrate
+docker compose exec backend bench --site your-site-name clear-cache
+```
+
+Use a backup or staging copy first if this is a production clinic database.

--- a/docker/apps.json
+++ b/docker/apps.json
@@ -1,0 +1,10 @@
+[
+  {
+    "url": "https://github.com/frappe/erpnext",
+    "branch": "version-15"
+  },
+  {
+    "url": "https://github.com/BaraaJayousi/optics_erp_15",
+    "branch": "main"
+  }
+]

--- a/docker/build.ps1
+++ b/docker/build.ps1
@@ -1,0 +1,37 @@
+param(
+    [string]$Image = "bgd4000/optics_erp",
+    [string]$Tag = "erpnext-v15",
+    [string]$FrappeDockerDir = "$PSScriptRoot\..\frappe_docker"
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    throw "git is required to clone or update frappe_docker."
+}
+
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    throw "Docker is required to build the image."
+}
+
+if (-not (Test-Path $FrappeDockerDir)) {
+    git clone --depth 1 https://github.com/frappe/frappe_docker.git $FrappeDockerDir
+} else {
+    git -C $FrappeDockerDir pull --ff-only
+}
+
+$appsJsonPath = Resolve-Path "$PSScriptRoot\apps.json"
+$appsJsonBase64 = [Convert]::ToBase64String([IO.File]::ReadAllBytes($appsJsonPath))
+$containerFile = Join-Path $FrappeDockerDir "images\custom\Containerfile"
+
+docker build `
+    --build-arg "FRAPPE_PATH=https://github.com/frappe/frappe" `
+    --build-arg "FRAPPE_BRANCH=version-15" `
+    --build-arg "APPS_JSON_BASE64=$appsJsonBase64" `
+    --tag "${Image}:${Tag}" `
+    --tag "${Image}:latest" `
+    --file $containerFile `
+    $FrappeDockerDir
+
+Write-Host "Built ${Image}:${Tag} and ${Image}:latest"
+Write-Host "Push with: docker push ${Image}:${Tag}; docker push ${Image}:latest"

--- a/optics_erp/hooks.py
+++ b/optics_erp/hooks.py
@@ -8,7 +8,7 @@ app_license = "apache-2.0"
 # Apps
 # ------------------
 
-# required_apps = []
+required_apps = ["erpnext"]
 
 # Each item in the list will be shown as an app in the apps page
 # add_to_apps_screen = [
@@ -242,4 +242,3 @@ doc_events = {
 # default_log_clearing_doctypes = {
 # 	"Logging DocType Name": 30  # days to retain logs
 # }
-


### PR DESCRIPTION
## Summary

- declare ERPNext as a required app for Optics ERP
- add an ERPNext 15 apps manifest for custom Docker builds
- add a Windows PowerShell build script for `bgd4000/optics_erp`
- add a GitHub Actions workflow to rebuild and push the Docker image on demand, weekly, and after relevant main-branch changes

## Validation

- parsed `docker/apps.json` with `python -m json.tool`
- parsed `.github/workflows/docker-image.yml` with PyYAML
- ran `git diff --check`

## Notes

Docker Hub publishing requires repository secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`.